### PR TITLE
CRC Repairing, DOS Stub Restoration, SizeOfImage Fix

### DIFF
--- a/Steamless.API/Crypto/CheckSumHelper.cs
+++ b/Steamless.API/Crypto/CheckSumHelper.cs
@@ -1,0 +1,73 @@
+﻿/**
+ * Steamless - Copyright (c) 2015 - 2019 atom0s [atom0s@live.com]
+ *
+ * This work is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
+ * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * By using Steamless, you agree to the above license and its terms.
+ *
+ *      Attribution - You must give appropriate credit, provide a link to the license and indicate if changes were
+ *                    made. You must do so in any reasonable manner, but not in any way that suggests the licensor
+ *                    endorses you or your use.
+ *
+ *   Non-Commercial - You may not use the material (Steamless) for commercial purposes.
+ *
+ *   No-Derivatives - If you remix, transform, or build upon the material (Steamless), you may not distribute the
+ *                    modified material. You are, however, allowed to submit the modified works back to the original
+ *                    Steamless project in attempt to have it added to the original project.
+ *
+ * You may not apply legal terms or technological measures that legally restrict others
+ * from doing anything the license permits.
+ *
+ * No warranties are given.
+ */
+
+namespace Steamless.API.Crypto
+{
+    using System.Runtime.InteropServices;
+
+    public static class CheckSumHelper
+    {
+        [DllImport("imagehlp", EntryPoint = "MapFileAndCheckSumW", ExactSpelling = false, CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern uint MapFileAndCheckSum(string Filename, out uint HeaderSum, out uint CheckSum);
+
+        public enum CheckSum_Result
+        {
+            /// <summary>
+            /// Initializing
+            ///
+            /// The function succeeded.
+            /// </summary>
+            CHECKSUM_SUCCESS = 0,
+
+            /// <summary>
+            /// Initializing
+            ///
+            /// Could not open the file.
+            /// </summary>
+            CHECKSUM_OPEN_FAILURE = 1,
+
+            /// <summary>
+            /// Initializing
+            ///
+            /// Could not map the file.
+            /// </summary>
+            CHECKSUM_MAP_FAILURE = 2,
+
+            /// <summary>
+            /// Initializing
+            ///
+            /// Could not map a view of the file.
+            /// </summary>
+            CHECKSUM_MAPVIEW_FAILURE = 3,
+
+            /// <summary>
+            /// Initializing
+            ///
+            /// Could not convert the file name to Unicode.
+            /// </summary>
+            CHECKSUM_UNICODE_FAILURE = 4
+        }
+    }
+}

--- a/Steamless.API/Model/SteamlessOptions.cs
+++ b/Steamless.API/Model/SteamlessOptions.cs
@@ -37,8 +37,8 @@ namespace Steamless.API.Model
             this.DumpPayloadToDisk = false;
             this.DumpSteamDrmpToDisk = false;
             this.UseExperimentalFeatures = false;
-            this.CleanDosStub = true;
-            this.RepairCrcChecksum = true;
+            this.CleanDosStub = false;
+            this.RepairCrcChecksum = false;
         }
 
         /// <summary>

--- a/Steamless.API/Model/SteamlessOptions.cs
+++ b/Steamless.API/Model/SteamlessOptions.cs
@@ -37,6 +37,8 @@ namespace Steamless.API.Model
             this.DumpPayloadToDisk = false;
             this.DumpSteamDrmpToDisk = false;
             this.UseExperimentalFeatures = false;
+            this.CleanDosStub = true;
+            this.RepairCrcChecksum = true;
         }
 
         /// <summary>
@@ -82,6 +84,24 @@ namespace Steamless.API.Model
         {
             get => this.Get<bool>("UseExperimentalFeatures");
             set => this.Set("UseExperimentalFeatures", value);
+        }
+
+        /// <summary>
+        /// Gets or sets the clean DOS stub option value.
+        /// </summary>
+        public bool CleanDosStub
+        {
+            get => this.Get<bool>("CleanDosStub");
+            set => this.Set("CleanDosStub", value);
+        }
+
+        /// <summary>
+        /// Gets or sets the repair crc checksum option value.
+        /// </summary>
+        public bool RepairCrcChecksum
+        {
+            get => this.Get<bool>("RepairCrcChecksum");
+            set => this.Set("RepairCrcChecksum", value);
         }
     }
 }

--- a/Steamless.API/PE32/Pe32File.cs
+++ b/Steamless.API/PE32/Pe32File.cs
@@ -307,27 +307,19 @@ namespace Steamless.API.PE32
         /// </summary>
         public void RebuildSections()
         {
-            uint biggestSectionSize = 0;
-            for (var x = 0; x < this.Sections.Count; x++)
-            {
-                // Obtain the current section and realign the data..
-                var section = this.Sections[x];
-                /*section.VirtualAddress = this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
-                section.VirtualSize = this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
-                section.PointerToRawData = this.GetAlignment(section.PointerToRawData, this.NtHeaders.OptionalHeader.FileAlignment);
-                section.SizeOfRawData = this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);*/
-                
-                // Determine if this Section (aligned) is the biggest..
-                if ((uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment) > biggestSectionSize)
-                    biggestSectionSize = (uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
+            uint sizeOfImage = 0;
 
-                // Store the sections updates..
-                this.Sections[x] = section;
-            }
+            // Add sizes of Dos Stub and Optional Header..
+            sizeOfImage += this.DosStubSize;
+            sizeOfImage += this.NtHeaders.FileHeader.SizeOfOptionalHeader;
+
+            // Add sizes of Sections aligned but do not align..
+            foreach (var section in this.Sections)
+                sizeOfImage += (uint)this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = biggestSectionSize;
+            ntHeaders.OptionalHeader.SizeOfImage = (uint)this.GetAlignment(sizeOfImage, this.NtHeaders.OptionalHeader.SectionAlignment);
             this.NtHeaders = ntHeaders;
         }
 

--- a/Steamless.API/PE32/Pe32File.cs
+++ b/Steamless.API/PE32/Pe32File.cs
@@ -322,7 +322,7 @@ namespace Steamless.API.PE32
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize;
+            ntHeaders.OptionalHeader.SizeOfImage = this.GetAlignment(this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
             this.NtHeaders = ntHeaders;
         }
 

--- a/Steamless.API/PE32/Pe32File.cs
+++ b/Steamless.API/PE32/Pe32File.cs
@@ -307,14 +307,19 @@ namespace Steamless.API.PE32
         /// </summary>
         public void RebuildSections()
         {
+            uint biggestSectionSize = 0;
             for (var x = 0; x < this.Sections.Count; x++)
             {
                 // Obtain the current section and realign the data..
                 var section = this.Sections[x];
-                section.VirtualAddress = this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
+                /*section.VirtualAddress = this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
                 section.VirtualSize = this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
                 section.PointerToRawData = this.GetAlignment(section.PointerToRawData, this.NtHeaders.OptionalHeader.FileAlignment);
-                section.SizeOfRawData = this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);
+                section.SizeOfRawData = this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);*/
+                
+                // Determine if this Section (aligned) is the biggest..
+                if ((uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment) > biggestSectionSize)
+                    biggestSectionSize = (uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
 
                 // Store the sections updates..
                 this.Sections[x] = section;
@@ -322,7 +327,7 @@ namespace Steamless.API.PE32
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = this.GetAlignment(this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
+            ntHeaders.OptionalHeader.SizeOfImage = biggestSectionSize;
             this.NtHeaders = ntHeaders;
         }
 

--- a/Steamless.API/PE64/Pe64File.cs
+++ b/Steamless.API/PE64/Pe64File.cs
@@ -322,7 +322,7 @@ namespace Steamless.API.PE64
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize;
+            ntHeaders.OptionalHeader.SizeOfImage = (uint)this.GetAlignment(this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
             this.NtHeaders = ntHeaders;
         }
 

--- a/Steamless.API/PE64/Pe64File.cs
+++ b/Steamless.API/PE64/Pe64File.cs
@@ -312,10 +312,10 @@ namespace Steamless.API.PE64
             {
                 // Obtain the current section and realign the data..
                 var section = this.Sections[x];
-                section.VirtualAddress = (uint)this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
+                /*section.VirtualAddress = (uint)this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
                 section.VirtualSize = (uint)this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
                 section.PointerToRawData = (uint)this.GetAlignment(section.PointerToRawData, this.NtHeaders.OptionalHeader.FileAlignment);
-                section.SizeOfRawData = (uint)this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);
+                section.SizeOfRawData = (uint)this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);*/
 
                 // Determine if this Section (aligned) is the biggest..
                 if ((uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment) > biggestSectionSize)

--- a/Steamless.API/PE64/Pe64File.cs
+++ b/Steamless.API/PE64/Pe64File.cs
@@ -307,30 +307,21 @@ namespace Steamless.API.PE64
         /// </summary>
         public void RebuildSections()
         {
-            uint biggestSectionSize = 0;
-            for (var x = 0; x < this.Sections.Count; x++)
-            {
-                // Obtain the current section and realign the data..
-                var section = this.Sections[x];
-                /*section.VirtualAddress = (uint)this.GetAlignment(section.VirtualAddress, this.NtHeaders.OptionalHeader.SectionAlignment);
-                section.VirtualSize = (uint)this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
-                section.PointerToRawData = (uint)this.GetAlignment(section.PointerToRawData, this.NtHeaders.OptionalHeader.FileAlignment);
-                section.SizeOfRawData = (uint)this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);*/
+            uint sizeOfImage = 0;
 
-                // Determine if this Section (aligned) is the biggest..
-                if ((uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment) > biggestSectionSize)
-                    biggestSectionSize = (uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
+            // Add sizes of Dos Stub and Optional Header..
+            sizeOfImage += (uint)this.DosStubSize;
+            sizeOfImage += this.NtHeaders.FileHeader.SizeOfOptionalHeader;
 
-                // Store the sections updates..
-                this.Sections[x] = section;
-            }
+            // Add sizes of Sections aligned but do not align..
+            foreach (var section in this.Sections)
+                sizeOfImage += (uint)this.GetAlignment(section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = biggestSectionSize;
+            ntHeaders.OptionalHeader.SizeOfImage = (uint)this.GetAlignment(sizeOfImage, this.NtHeaders.OptionalHeader.SectionAlignment);
             this.NtHeaders = ntHeaders;
         }
-
         /// <summary>
         /// Obtains the relative virtual address from the given virtual address.
         /// </summary>

--- a/Steamless.API/PE64/Pe64File.cs
+++ b/Steamless.API/PE64/Pe64File.cs
@@ -307,6 +307,7 @@ namespace Steamless.API.PE64
         /// </summary>
         public void RebuildSections()
         {
+            uint biggestSectionSize = 0;
             for (var x = 0; x < this.Sections.Count; x++)
             {
                 // Obtain the current section and realign the data..
@@ -316,13 +317,17 @@ namespace Steamless.API.PE64
                 section.PointerToRawData = (uint)this.GetAlignment(section.PointerToRawData, this.NtHeaders.OptionalHeader.FileAlignment);
                 section.SizeOfRawData = (uint)this.GetAlignment(section.SizeOfRawData, this.NtHeaders.OptionalHeader.FileAlignment);
 
+                // Determine if this Section (aligned) is the biggest..
+                if ((uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment) > biggestSectionSize)
+                    biggestSectionSize = (uint)this.GetAlignment(section.VirtualAddress + section.VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
+
                 // Store the sections updates..
                 this.Sections[x] = section;
             }
 
             // Update the size of the image..
             var ntHeaders = this.NtHeaders;
-            ntHeaders.OptionalHeader.SizeOfImage = (uint)this.GetAlignment(this.Sections.Last().VirtualAddress + this.Sections.Last().VirtualSize, this.NtHeaders.OptionalHeader.SectionAlignment);
+            ntHeaders.OptionalHeader.SizeOfImage = biggestSectionSize;
             this.NtHeaders = ntHeaders;
         }
 

--- a/Steamless.API/Steamless.API.csproj
+++ b/Steamless.API/Steamless.API.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Crypto\AesHelper.cs" />
+    <Compile Include="Crypto\CheckSumHelper.cs" />
     <Compile Include="Extensions\FileStreamExtensions.cs" />
     <Compile Include="Model\NavigatedEventArgs.cs" />
     <Compile Include="Model\NotifiableModel.cs" />

--- a/Steamless.Unpacker.Variant20.x86/Main.cs
+++ b/Steamless.Unpacker.Variant20.x86/Main.cs
@@ -174,7 +174,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #1
-        /// 
+        ///
         /// Read, disassemble and decode the SteamStub DRM header.
         /// </summary>
         /// <returns></returns>
@@ -209,7 +209,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #2
-        /// 
+        ///
         /// Read, decode and process the payload data.
         /// </summary>
         /// <returns></returns>
@@ -242,7 +242,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #3
-        /// 
+        ///
         /// Read, decode and dump the SteamDRMP.dll file.
         /// </summary>
         /// <returns></returns>
@@ -292,7 +292,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #4
-        /// 
+        ///
         /// Scan, dump and pull needed offsets from within the SteamDRMP.dll file.
         /// </summary>
         /// <returns></returns>
@@ -333,7 +333,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #5
-        /// 
+        ///
         /// Read, decrypt and process the main code section.
         /// </summary>
         /// <returns></returns>
@@ -421,7 +421,7 @@ namespace Steamless.Unpacker.Variant20.x86
 
         /// <summary>
         /// Step #6
-        /// 
+        ///
         /// Rebuild and save the unpacked file.
         /// </summary>
         /// <returns></returns>
@@ -441,9 +441,23 @@ namespace Steamless.Unpacker.Variant20.x86
                 // Write the DOS header to the file..
                 fStream.WriteBytes(Pe32Helpers.GetStructureBytes(this.File.DosHeader));
 
+                var dosHeaderSize = fStream.Position;
+
                 // Write the DOS stub to the file..
                 if (this.File.DosStubSize > 0)
+                {
+                    if (this.Options.CleanDosStub)
+                    {
+                        byte[] cleanDosStub = new byte[] { 0x0E, 0x1F, 0xBA, 0x0E, 0x00, 0xB4, 0x09, 0xCD, 0x21, 0xB8, 0x01, 0x4C, 0xCD, 0x21, 0x54, 0x68, 0x69, 0x73, 0x20, 0x70, 0x72, 0x6F, 0x67, 0x72, 0x61, 0x6D, 0x20, 0x63, 0x61, 0x6E, 0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x72, 0x75, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x44, 0x4F, 0x53, 0x20, 0x6D, 0x6F, 0x64, 0x65, 0x2E, 0x0D, 0x0D, 0x0A, 0x24 };
+                        this.Log(" --> cleaning DOS stub.", LogMessageType.Debug);
+                        this.File.DosStubData = new byte[this.File.DosStubSize];
+                        Array.Copy(cleanDosStub, this.File.DosStubData, cleanDosStub.Length);
+                    }
+                    else
+                        this.Log(" --> retaining DOS stub.", LogMessageType.Debug);
+
                     fStream.WriteBytes(this.File.DosStubData);
+                }
 
                 // Update the NT headers..
                 var ntHeaders = this.File.NtHeaders;
@@ -486,6 +500,30 @@ namespace Steamless.Unpacker.Variant20.x86
                 // Write the overlay data if it exists..
                 if (this.File.OverlayData != null)
                     fStream.WriteBytes(this.File.OverlayData);
+
+                // Repair CRC checksum if not zero
+                if (this.Options.RepairCrcChecksum)
+                {
+                    uint newChecksum = 0;
+
+                    ntHeaders = this.File.NtHeaders;
+                    fStream.Position = dosHeaderSize + (long)this.File.DosStubSize;
+
+                    this.Log($" --> current CRC checksum is {ntHeaders.OptionalHeader.CheckSum}.", LogMessageType.Debug);
+
+                    var checksumResult = CheckSumHelper.MapFileAndCheckSum(fStream.Name, out ntHeaders.OptionalHeader.CheckSum, out newChecksum);
+
+                    if ((CheckSumHelper.CheckSum_Result)checksumResult == CheckSumHelper.CheckSum_Result.CHECKSUM_SUCCESS)
+                        ntHeaders.OptionalHeader.CheckSum = newChecksum;
+                    else
+                        ntHeaders.OptionalHeader.CheckSum = 0;
+
+                    this.File.NtHeaders = ntHeaders;
+
+                    fStream.WriteBytes(Pe32Helpers.GetStructureBytes(ntHeaders));
+
+                    this.Log($" --> repaired CRC checksum is {newChecksum}.", LogMessageType.Debug);
+                }
 
                 this.Log(" --> Unpacked file saved to disk!", LogMessageType.Success);
                 this.Log($" --> File Saved As: {unpackedPath}", LogMessageType.Success);

--- a/Steamless.Unpacker.Variant31.x86/Main.cs
+++ b/Steamless.Unpacker.Variant31.x86/Main.cs
@@ -195,7 +195,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #1
-        /// 
+        ///
         /// Read, decode and validate the SteamStub DRM header.
         /// </summary>
         /// <returns></returns>
@@ -240,7 +240,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #2
-        /// 
+        ///
         /// Read, decode and process the payload data.
         /// </summary>
         /// <returns></returns>
@@ -279,7 +279,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #3
-        /// 
+        ///
         /// Read, decode and dump the SteamDRMP.dll file.
         /// </summary>
         /// <returns></returns>
@@ -329,7 +329,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #4
-        /// 
+        ///
         /// Remove the bind section if requested.
         /// Find the code section.
         /// </summary>
@@ -374,7 +374,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #5
-        /// 
+        ///
         /// Read, decrypt and process the code section.
         /// </summary>
         /// <returns></returns>
@@ -422,7 +422,7 @@ namespace Steamless.Unpacker.Variant31.x86
 
         /// <summary>
         /// Step #6
-        /// 
+        ///
         /// Rebuild and save the unpacked file.
         /// </summary>
         /// <returns></returns>
@@ -442,9 +442,23 @@ namespace Steamless.Unpacker.Variant31.x86
                 // Write the DOS header to the file..
                 fStream.WriteBytes(Pe32Helpers.GetStructureBytes(this.File.DosHeader));
 
+                var dosHeaderSize = fStream.Position;
+
                 // Write the DOS stub to the file..
                 if (this.File.DosStubSize > 0)
+                {
+                    if (this.Options.CleanDosStub)
+                    {
+                        byte[] cleanDosStub = new byte[] { 0x0E, 0x1F, 0xBA, 0x0E, 0x00, 0xB4, 0x09, 0xCD, 0x21, 0xB8, 0x01, 0x4C, 0xCD, 0x21, 0x54, 0x68, 0x69, 0x73, 0x20, 0x70, 0x72, 0x6F, 0x67, 0x72, 0x61, 0x6D, 0x20, 0x63, 0x61, 0x6E, 0x6E, 0x6F, 0x74, 0x20, 0x62, 0x65, 0x20, 0x72, 0x75, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x44, 0x4F, 0x53, 0x20, 0x6D, 0x6F, 0x64, 0x65, 0x2E, 0x0D, 0x0D, 0x0A, 0x24 };
+                        this.Log(" --> cleaning DOS stub.", LogMessageType.Debug);
+                        this.File.DosStubData = new byte[this.File.DosStubSize];
+                        Array.Copy(cleanDosStub, this.File.DosStubData, cleanDosStub.Length);
+                    }
+                    else
+                        this.Log(" --> retaining DOS stub.", LogMessageType.Debug);
+
                     fStream.WriteBytes(this.File.DosStubData);
+                }
 
                 // Update the entry point of the file..
                 var ntHeaders = this.File.NtHeaders;
@@ -484,6 +498,30 @@ namespace Steamless.Unpacker.Variant31.x86
                 // Write the overlay data if it exists..
                 if (this.File.OverlayData != null)
                     fStream.WriteBytes(this.File.OverlayData);
+
+                // Repair CRC checksum if not zero
+                if (this.Options.RepairCrcChecksum)
+                {
+                    uint newChecksum = 0;
+
+                    ntHeaders = this.File.NtHeaders;
+                    fStream.Position = dosHeaderSize + (long)this.File.DosStubSize;
+
+                    this.Log($" --> current CRC checksum is {ntHeaders.OptionalHeader.CheckSum}.", LogMessageType.Debug);
+
+                    var checksumResult = CheckSumHelper.MapFileAndCheckSum(fStream.Name, out ntHeaders.OptionalHeader.CheckSum, out newChecksum);
+
+                    if ((CheckSumHelper.CheckSum_Result)checksumResult == CheckSumHelper.CheckSum_Result.CHECKSUM_SUCCESS)
+                        ntHeaders.OptionalHeader.CheckSum = newChecksum;
+                    else
+                        ntHeaders.OptionalHeader.CheckSum = 0;
+
+                    this.File.NtHeaders = ntHeaders;
+
+                    fStream.WriteBytes(Pe32Helpers.GetStructureBytes(ntHeaders));
+
+                    this.Log($" --> repaired CRC checksum is {newChecksum}.", LogMessageType.Debug);
+                }
 
                 this.Log(" --> Unpacked file saved to disk!", LogMessageType.Success);
                 this.Log($" --> File Saved As: {unpackedPath}", LogMessageType.Success);


### PR DESCRIPTION
First time performing a Pull Request for any public project. Not sure why the Main.cs changes look so drastic in web diff compared to local diff.

I've come across PE32s protected with SteamDRM that use a per-user unique VLV section that takes the place of the DOS stub. Not only should executables have a proper DOS stub (though mostly irrelevant these days), the data could be used to identify users. Clearing the entire stub and restoring the _de facto_ DOS stub most commonly seen can help protect build leaks.

It is recommended and common that a PE32 have a correct CRC checksum (or if undesired, Zero, for non-critical software). The CRC checksum can also identify per-user unique builds and should either be set Zero for non-critical software or set to the unpacked PE32.

It is required that PE32s have their SizeOfImage set to a multiple of SectionAlignment (rounded upward, zero-filled recommended). I have modified Pe32/64.cs to do just this.

I've added options and the code to address these considerations. I would like them to be considered, perhaps reworked if necessary, but considered at least.