### PR TITLE
Add option to remove Security Directory

### DIFF
--- a/Steamless.API/Model/SteamlessOptions.cs
+++ b/Steamless.API/Model/SteamlessOptions.cs
@@ -40,6 +40,7 @@ namespace Steamless.API.Model
             this.DontRealignSections = true;
             this.ZeroDosStubData = true;
             this.RecalculateFileChecksum = false;
+            this.RemoveCertificateTable = true;
         }
 
         /// <summary>
@@ -112,6 +113,12 @@ namespace Steamless.API.Model
         {
             get => this.Get<bool>("RecalculateFileChecksum");
             set => this.Set("RecalculateFileChecksum", value);
+        }
+
+        public bool RemoveCertificateTable
+        {
+            get => this.Get<bool>("RemoveCertificateTable");
+            set => this.Set("RemoveCertificateTable", value);
         }
     }
 }

--- a/Steamless.Unpacker.Variant31.x64/Main.cs
+++ b/Steamless.Unpacker.Variant31.x64/Main.cs
@@ -463,6 +463,13 @@ namespace Steamless.Unpacker.Variant31.x64
                 var ntHeaders = this.File.NtHeaders;
                 ntHeaders.OptionalHeader.AddressOfEntryPoint = (uint)this.StubHeader.OriginalEntryPoint;
                 ntHeaders.OptionalHeader.CheckSum = 0;
+
+                if(this.Options.RemoveCertificateTable)
+                {
+                    ntHeaders.OptionalHeader.CertificateTable.Size = 0;
+                    ntHeaders.OptionalHeader.CertificateTable.VirtualAddress = 0;
+                }
+
                 this.File.NtHeaders = ntHeaders;
 
                 // Write the NT headers to the file..

--- a/Steamless/View/MainView.xaml
+++ b/Steamless/View/MainView.xaml
@@ -87,6 +87,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <CheckBox Grid.Row="0" Content="Verbose Output" Margin="2" ToolTip="If enabled, Steamless will allow logging of debug messages." IsChecked="{Binding Options.VerboseOutput}" />
                 <CheckBox Grid.Row="1" Content="Keep Bind Section" Margin="2" ToolTip="The bind section should be kept within the file after unpacking." IsChecked="{Binding Options.KeepBindSection}" />
@@ -96,6 +97,7 @@
                 <CheckBox Grid.Row="5" Content="Don't Realign Sections" Margin="2" ToolTip="Disables realignment of sections when unpacking." IsChecked="{Binding Options.DontRealignSections}" />
                 <CheckBox Grid.Row="6" Content="Zero DOS Stub Data" Margin="2" ToolTip="Sets the DOS stub data to 00's." IsChecked="{Binding Options.ZeroDosStubData}" />
                 <CheckBox Grid.Row="7" Content="Recalculate File Checksum" Margin="2" ToolTip="Recalculates the file checksum in the unpacked file." IsChecked="{Binding Options.RecalculateFileChecksum}" />
+                <CheckBox Grid.Row="8" Content="Remove Certificate Table" Margin="2" ToolTip="Removes the security directory from the optional data directories." IsChecked="{Binding Options.RemoveCertificateTable}" />
             </Grid>
         </GroupBox>
 


### PR DESCRIPTION
This resolves error 0x800700C1 in signtool if the PE was previously signed.

Currently only implemented for Variant 3.1 x64

Steps to reproduce:

Use Steamless to remove SteamStub from Oblivion Remastered
Attempt to sign the output binary with signtool
Receive error 0x800700C1
<img width="544" alt="{C1E80824-AF87-4280-86F8-41D01CACFD1B}" src="https://github.com/user-attachments/assets/265c08a0-0de7-4822-b72b-6391dcfee797" />
